### PR TITLE
feat: SYGN-10934 add RON, AXS, PYTH, NIDT

### DIFF
--- a/coingecko_id/mapping.json
+++ b/coingecko_id/mapping.json
@@ -8678,5 +8678,17 @@
     {
         "currency_id": "sygna:0x80776773",
         "coingecko_id": "observer-coin"
+    },
+    {
+        "currency_id": "sygna:ronin",
+        "coingecko_id": "ronin"
+    },
+    {
+        "currency_id": "sygna:ronin.0x97a9107c1793bc407d6f527b77e7fff4d812bece",
+        "coingecko_id": "axie-infinity"
+    },
+    {
+        "currency_id": "sygna:0x800001f5.HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3",
+        "coingecko_id": "pyth-network"
     }
 ]

--- a/cryptocurrency/sygna:0x8000003c.0x8CA328bB08B0AB920E792E5c67b718De4330Fc9D.json
+++ b/cryptocurrency/sygna:0x8000003c.0x8CA328bB08B0AB920E792E5c67b718De4330Fc9D.json
@@ -1,0 +1,13 @@
+{
+    "currency_id": "sygna:0x8000003c.0x8CA328bB08B0AB920E792E5c67b718De4330Fc9D",
+    "currency_name": "Nippon Idol Token on Ethereum",
+    "currency_symbol": "NIDT",
+    "is_active": true,
+    "addr_extra_info": [],
+    "platform": {
+        "name": "Ethereum",
+        "symbol": "ETH",
+        "token_address": "0x8CA328bB08B0AB920E792E5c67b718De4330Fc9D",
+        "id": "sygna:0x8000003c"
+    }
+}

--- a/cryptocurrency/sygna:0x800001f5.HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3.json
+++ b/cryptocurrency/sygna:0x800001f5.HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3.json
@@ -1,0 +1,13 @@
+{
+    "currency_id": "sygna:0x800001f5.HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3",
+    "currency_name": "Pyth Network on Solana",
+    "currency_symbol": "PYTH",
+    "is_active": true,
+    "addr_extra_info": [],
+    "platform": {
+        "name": "Solana",
+        "symbol": "SOL",
+        "token_address": "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3",
+        "id": "sygna:0x800001f5"
+    }
+}

--- a/cryptocurrency/sygna:ronin.0x97a9107c1793bc407d6f527b77e7fff4d812bece.json
+++ b/cryptocurrency/sygna:ronin.0x97a9107c1793bc407d6f527b77e7fff4d812bece.json
@@ -1,0 +1,13 @@
+{
+    "currency_id": "sygna:ronin.0x97a9107c1793bc407d6f527b77e7fff4d812bece",
+    "currency_name": "Axie Infinity on Ronin",
+    "currency_symbol": "AXS",
+    "is_active": true,
+    "addr_extra_info": [],
+    "platform": {
+        "name": "Ronin",
+        "symbol": "RON",
+        "token_address": "0x97a9107c1793bc407d6f527b77e7fff4d812bece",
+        "id": "sygna:ronin"
+    }
+}

--- a/cryptocurrency/sygna:ronin.json
+++ b/cryptocurrency/sygna:ronin.json
@@ -1,0 +1,8 @@
+{
+    "currency_id": "sygna:ronin",
+    "currency_name": "Ronin",
+    "currency_symbol": "RON",
+    "is_active": true,
+    "addr_extra_info": [],
+    "platform": null
+}


### PR DESCRIPTION
Ronin 在 [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) 內找不到對應的 Path component
故直接以 `sygna:ronin` 來當作 currency_id

而 Nippon Idol Token on Ethereum 則是找不到對應的 CoinGecko id
