### PR TITLE
feat: Edit SXP-on-Solar

### DIFF
--- a/cryptocurrency/sygna:0x80000d05.json
+++ b/cryptocurrency/sygna:0x80000d05.json
@@ -4,5 +4,10 @@
     "currency_symbol": "SXP",
     "is_active": true,
     "addr_extra_info": [],
-    "platform": null
+    "platform": {
+        "name": "Solar",
+        "symbol": "SXP",
+        "token_address": "",
+        "id": "sygna:0x80000d05"
+    }
 }


### PR DESCRIPTION
Swipe是Solar的前身，名字換掉了但symbol一樣是SXP，由於不確定客戶那邊是否已全面更換名字（若有交易所維持舊名字可能造成系統誤判導致交易被拒絕），因此修改json內容
