### PR TITLE
fix: SYGN-18584 mark APT token is_active false

### DIFF
--- a/cryptocurrency/sygna-0x8000027d.0x1::aptos_coin::AptosCoin.json
+++ b/cryptocurrency/sygna-0x8000027d.0x1::aptos_coin::AptosCoin.json
@@ -1,0 +1,1 @@
+{"currency_id":"sygna:0x8000027d.0x1::aptos_coin::AptosCoin","currency_name":"Aptos","currency_symbol":"APT","is_active":false,"addr_extra_info":[],"platform":{"name":"Aptos","symbol":"APT","token_address":"0x1::aptos_coin::AptosCoin","id":"sygna:0x8000027d"}}


### PR DESCRIPTION
VASP might already onboard `sygna:0x8000027d.0x1::aptos_coin::AptosCoin` in their system.
To avoid possible error, mark this token `inactive` instead of directly removing it.